### PR TITLE
Pusher signature incorrectly generated on Windows systems

### DIFF
--- a/src/ZfrPusher/Client/PusherSignature.php
+++ b/src/ZfrPusher/Client/PusherSignature.php
@@ -62,7 +62,7 @@ class PusherSignature
         $requestPath = $request->getPath();
         $query       = urldecode(http_build_query($queryParameters));
 
-        $signature   = $this->signString(implode(PHP_EOL, array($method, $requestPath, $query)), $credentials);
+        $signature   = $this->signString(implode("\n", array($method, $requestPath, $query)), $credentials);
 
         $queryParameters['auth_signature'] = $signature;
 


### PR DESCRIPTION
The Pusher API specifically expects a signature to be calculated on a string joined with "\n" newline type. The use of PHP_EOL causes the signature to be incorrectly generated on Windows systems.
