### PR TITLE
Improve guzzle dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "guzzle/guzzle": ">=3.5,<=3.8"
+        "guzzle/guzzle": "~3.5"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Allow any guzzle 3.x provided that it is equal to or greater than 3.5.
