### PR TITLE
Fix the call to $service->trigger() with no socketId

### DIFF
--- a/src/ZfrPusher/Service/PusherService.php
+++ b/src/ZfrPusher/Service/PusherService.php
@@ -96,7 +96,7 @@ class PusherService
             $parameters['channels'] = $channels;
         }
 
-        if(isset($socketId)){
+        if(!empty($socketId)){
             $parameters['socket_id'] = $socketId;
         }
 
@@ -124,7 +124,7 @@ class PusherService
      * @param  string        $socketId Exclude a specific socket id from the event
      * @return void
      */
-    public function triggerAsync($channels, $event, array $data = array(), $socketId = '')
+    public function triggerAsync($channels, $event, array $data = array(), $socketId = null)
     {
         $this->trigger($event, $channels, $data, $socketId, true);
     }

--- a/src/ZfrPusher/Service/PusherService.php
+++ b/src/ZfrPusher/Service/PusherService.php
@@ -83,18 +83,21 @@ class PusherService
      * @param  bool          $async    If true, the request is performed asynchronously
      * @return void
      */
-    public function trigger($channels, $event, array $data = array(), $socketId = '', $async = false)
+    public function trigger($channels, $event, array $data = array(), $socketId = null, $async = false)
     {
         $parameters = array(
             'event'     => $event,
-            'data'      => $data,
-            'socket_id' => $socketId
+            'data'      => $data
         );
 
         if (is_string($channels)) {
             $parameters['channel'] = $channels;
         } elseif (is_array($channels)) {
             $parameters['channels'] = $channels;
+        }
+
+        if(isset($socketId)){
+            $parameters['socket_id'] = $socketId;
         }
 
         if ($async) {

--- a/tests/ZfrPusherTest/Service/PusherServiceTest.php
+++ b/tests/ZfrPusherTest/Service/PusherServiceTest.php
@@ -98,13 +98,49 @@ class PusherServiceTest extends PHPUnit_Framework_TestCase
     /**
      * @covers PusherService::trigger
      */
+    public function testTriggerWithSocketIdEmpty()
+    {
+        $expectedParameters = array(
+            'event'     => 'my-event',
+            'channel'   => 'my-channel',
+            'data'      => array()
+        );
+
+        $this->client->expects($this->once())
+                     ->method('trigger')
+                     ->with($expectedParameters);
+
+        $this->service->trigger('my-channel', 'my-event', array(), '');
+    }
+
+    /**
+     * @covers PusherService::trigger
+     */
+    public function testTriggerWithSocketId()
+    {
+        $expectedParameters = array(
+            'event'      => 'my-event',
+            'channel'    => 'my-channel',
+            'data'       => array(),
+            'socket_id'  => '123.123'
+        );
+
+        $this->client->expects($this->once())
+                     ->method('trigger')
+                     ->with($expectedParameters);
+
+        $this->service->trigger('my-channel', 'my-event', array(), '123.123');
+    }
+
+    /**
+     * @covers PusherService::trigger
+     */
     public function testTriggerUseChannelIfString()
     {
         $expectedParameters = array(
             'event'     => 'my-event',
             'channel'   => 'my-channel',
-            'data'      => array(),
-            'socket_id' => ''
+            'data'      => array()
         );
 
         $this->client->expects($this->once())
@@ -122,8 +158,7 @@ class PusherServiceTest extends PHPUnit_Framework_TestCase
         $expectedParameters = array(
             'event'     => 'my-event',
             'channels'  => array('my-channel-1', 'my-channel-2'),
-            'data'      => array(),
-            'socket_id' => ''
+            'data'      => array()
         );
 
         $this->client->expects($this->once())


### PR DESCRIPTION
Because of the regex on the socket id, the call will reject an empty string (''). As such, I changed the code to only add the property when necessary.